### PR TITLE
Prevent RMI random port

### DIFF
--- a/src/canreg/server/CanRegLoginImpl.java
+++ b/src/canreg/server/CanRegLoginImpl.java
@@ -44,6 +44,9 @@ public class CanRegLoginImpl extends UnicastRemoteObject
      */
     public CanRegLoginImpl(CanRegServerInterface server)
             throws RemoteException, MalformedURLException {
+        // Prevent JAVA to use a random port.
+        super(1099);
+        
         System.setProperty("java.security.auth.login.config", Globals.LOGIN_FILENAME);
         System.setProperty("java.security.policy", Globals.POLICY_FILENAME);
         this.theServer = server;

--- a/src/canreg/server/CanRegServerImpl.java
+++ b/src/canreg/server/CanRegServerImpl.java
@@ -96,6 +96,8 @@ public class CanRegServerImpl extends UnicastRemoteObject implements CanRegServe
      * @throws java.rmi.RemoteException
      */
     public CanRegServerImpl(String systemCode) throws RemoteException {
+        // Prevent JAVA to use a random port.
+        super(1099);
         
         Logger.getLogger(CanRegServerImpl.class.getName()).log(Level.INFO, "Java version: {0}", System.getProperty("java.version"));
                 

--- a/src/canreg/server/CanRegServerProxy.java
+++ b/src/canreg/server/CanRegServerProxy.java
@@ -56,6 +56,9 @@ class CanRegServerProxy extends UnicastRemoteObject implements CanRegServerInter
     private final Subject theUser;
 
     public CanRegServerProxy(Subject user, CanRegServerInterface server) throws RemoteException {
+        // Prevent JAVA to use a random port.
+        super(1099);
+        
         /** The user associated with this proxy
          */
         this.theUser = user;


### PR DESCRIPTION
For security reasons, the servers have only some open ports. But JAVA's RMI connection opens a random port. We want to prevent this JAVA behavior with this PR.

Now, by defaut port 1099 is used. It would only be necessary to add the option in the GUI to select which port to open. 